### PR TITLE
Guard split editor keybinding outside terminal

### DIFF
--- a/keybinding.json
+++ b/keybinding.json
@@ -108,7 +108,8 @@
   },
   {
     "key": "ctrl+shift+s",
-    "command": "workbench.action.splitEditorRight"
+    "command": "workbench.action.splitEditorRight",
+    "when": "!terminalFocus"
   },
   {
     "key": "ctrl+shift+s",


### PR DESCRIPTION
## Summary
- avoid duplicate execution of split editor and terminal actions for Ctrl+Shift+S by limiting editor binding to non-terminal focus

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a49cfedadc83238fb124303fde9110